### PR TITLE
Chore: Merges multiple nested if conditions into one

### DIFF
--- a/sqlmodel/sql/sqltypes.py
+++ b/sqlmodel/sql/sqltypes.py
@@ -52,9 +52,6 @@ class GUID(TypeDecorator):
                 return f"{value.int:x}"
 
     def process_result_value(self, value, dialect):
-        if value is None:
-            return value
-        else:
-            if not isinstance(value, uuid.UUID):
-                value = uuid.UUID(value)
-            return value
+        if value is not None and not isinstance(value, uuid.UUID):
+            value = uuid.UUID(value)
+        return value


### PR DESCRIPTION
- Merges multiple nested if conditions into one in this Function `SQLModel.__setattr__`

> Reading deeply nested code is confusing, since you have to keep track of which conditions relate to which levels. We therefore strive to reduce nesting where possible, and the situation where two if conditions can be combined using and is an easy win.

- Replaces conditional assignment to a variable with an `if` expression in this Function `SQLModel.from_orm`

> Once the change is made there's only one statement where `x` is defined as opposed to having to read two statements plus the `if-else` lines.

- Removes unnecessarily verbose boolean comparisons in this Function `SQLModel._calculate_keys`

> It is unnecessary to compare boolean values to True or False in the test of an if condition. Removing these unnecessary checks makes the code slightly shorter and easier to parse.

- Hoist repeated code outside conditional statement and Swap `if/else` to remove empty `if` body in this Function `GUID.process_result_value`

> By taking the assignment outside of the conditional we have removed a duplicate line of code, and made it clearer what the conditional is actually controlling.